### PR TITLE
Support loading pact contract from a pact broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ install: clean ## install the package to the active Python's site-packages
 # Pact broker
 # Install from https://github.com/pact-foundation/pact-ruby-standalone/releases
 
-broker-publish:
+broker-publish:  ## Publish test app pact contract to the pact broker
 	pact-broker publish \
 	test_app/pactfiles/TestConsumer-TestProvider-pact.json \
 	--consumer-app-version=`git rev-parse --short HEAD` \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
+export PACT_BROKER_BASE_URL=http://localhost:9292
+
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
@@ -100,3 +102,13 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+
+# Pact broker
+# Install from https://github.com/pact-foundation/pact-ruby-standalone/releases
+
+broker-publish:
+	pact-broker publish \
+	test_app/pactfiles/TestConsumer-TestProvider-pact.json \
+	--consumer-app-version=`git rev-parse --short HEAD` \
+	--tag=DEV

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,3 @@
+div.document {
+    width: 1070px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,9 @@ html_theme_options = {"logo": "pact-testgen-logo.png"}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+# Additional CSS
+html_css_files = ["custom.css"]
+
 
 # -- Options for HTMLHelp output ---------------------------------------
 

--- a/docs/pact_testgen.rst
+++ b/docs/pact_testgen.rst
@@ -11,6 +11,14 @@ Subpackages
 Submodules
 ----------
 
+pact\_testgen.broker module
+---------------------------
+
+.. automodule:: pact_testgen.broker
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 pact\_testgen.cli module
 ------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,8 +12,11 @@ Execute ``pact-testgen`` as follows:
 
     pact-testgen /path/to/pactfile.json /output/dir
 
+
 The output directory should be in your tests directory, where your
 test runner will pick it up.
+
+Alternately, ``pact-testgen`` can retrieve a Pact contract from a Pact Broker.
 
 This will create two files in the output directory:
 
@@ -47,21 +50,116 @@ which should make updates simpler, as well as simplify support for provider code
 with multiple consumers.
 
 
+
+Pact Broker
+-----------
+
+To retrieve a Pact contract from a Pact Broker instead of the local filesystem, provide the following parameters.
+Any parameter can be given using CLI arguments, or set as an environment variable. Parameters passed to the CLI
+will take precedence over environment variables.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 80 10 10 10
+
+   * - Parameter
+     - CLI
+     - Env var
+     - Required
+     - Notes
+
+   * - Base URL
+     - ``-b``, ``--broker-base-url``
+     - ``PACT_BROKER_BASE_URL``
+     - Yes
+     -
+
+   * - Provider Name
+     - ``-s``, ``--provider-name``
+     - ``PACT_BROKER_PROVIDER_NAME``
+     - Yes
+     -
+
+
+   * - Consumer Name
+     - ``-c``, ``--consumer-name``
+     - ``PACT_BROKER_CONSUMER_NAME``
+     - Yes
+     -
+
+
+   * - Consumer version
+     - ``-c``, ``--consumer-version``
+     - ``PACT_BROKER_CONSUMER_VERSION``
+     - No
+     - Defaults to "latest"
+
+
+Broker Authentication
++++++++++++++++++++++
+
+Currently, only basic authentication is supported.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 80 10 10 10
+
+   * - Parameter
+     - CLI
+     - Env var
+     - Required
+     - Notes
+
+   * - Broker Username
+     - ``-u``, ``--broker-username``
+     - ``PACT_BROKER_USERNAME``
+     - Yes
+     -
+
+
+   * - Broker Password
+     - ``-p``, ``--broker-password``
+     - ``PACT_BROKER_PASSWORD``
+     - Yes
+     -
+
 Help
 ----
 
 ::
 
-    usage: pact-testgen [-h] [--base-class BASE_CLASS] [--debug]
-                        pact_file output_dir
+    ❯ pact-testgen --help
+    usage: pact-testgen [-h] [-f PACT_FILE] [--base-class BASE_CLASS] [--line-length LINE_LENGTH] [--debug] [--version] [-q] [-m] [-b BROKER_BASE_URL] [-u BROKER_USERNAME] [-p BROKER_PASSWORD] [-c CONSUMER_NAME] [-s PROVIDER_NAME]
+                        [-v CONSUMER_VERSION]
+                        output_dir
 
     positional arguments:
-    pact_file             Path to a Pact file.
     output_dir            Output for generated Python files.
 
     optional arguments:
     -h, --help            show this help message and exit
+    -f PACT_FILE, --pact-file PACT_FILE
+                            Path to a Pact file.
     --base-class BASE_CLASS
-                            Python path to the TestCase which generated test cases
-                            will subclass.
+                            Python path to the TestCase which generated test cases will subclass.
+    --line-length LINE_LENGTH
+                            Target line length for generated files.
     --debug
+    --version             show program's version number and exit
+    -q, --quiet           Silence output
+    -m, --merge-provider-state-file
+                            Attempt to merge new provider state functions into existing provider state file. Only available on Python 3.9+.
+
+    pact broker arguments:
+    -b BROKER_BASE_URL, --broker-base-url BROKER_BASE_URL
+                            Pact broker base url. Optionally configure by setting the PACT_BROKER_BASE_URL environment variable.
+    -u BROKER_USERNAME, --broker-username BROKER_USERNAME
+                            Pact broker username.
+    -p BROKER_PASSWORD, --broker-password BROKER_PASSWORD
+                            Pact broker password.
+    -c CONSUMER_NAME, --consumer-name CONSUMER_NAME
+                            Consumer name used to retrieve Pact contract from the pact broker.
+    -s PROVIDER_NAME, --provider-name PROVIDER_NAME
+                            Provider name used to retrieve Pact contract from the pact broker.
+    -v CONSUMER_VERSION, --consumer-version CONSUMER_VERSION
+                            Consumer version number. Used to retrieve the Pact contract from the Pact broker. Optional, defaults to 'latest'.

--- a/pact_testgen/broker.py
+++ b/pact_testgen/broker.py
@@ -1,25 +1,21 @@
 import urllib
-from typing import Any, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import requests
-from pydantic import BaseSettings, Field
+from pydantic import BaseSettings
 from pydantic.env_settings import SettingsSourceCallable, InitSettingsSource
 
 from .models import Pact
 
 
-class BrokerConfig(BaseSettings):
-    # Same env vars as pact broker CLI client
-    # https://github.com/pact-foundation/pact_broker-client#usage---cli
-    base_url: str
-    username: str = Field(default="")
-    password: str = Field(default="")
+class BrokerBaseSettings(BaseSettings):
+    pass
 
     class Config:
         env_prefix = "pact_broker_"
 
-        # For broker settings, we want to allow passing None for username
-        # and password, and revert to loading from the environment. However,
+        # For broker settings, we want to allow passing values of None
+        # and revert to loading from the environment. However,
         # we also want to prioritize username and password if they are passed
         # as init kwargs, but are not None. This pattern simplifies CLI option
         # handling, at the expense of additional complexity here.
@@ -38,6 +34,18 @@ class BrokerConfig(BaseSettings):
                 file_secret_settings,
             )
 
+
+class BrokerBasicAuthConfig(BrokerBaseSettings):
+    username: str
+    password: str
+
+
+class BrokerConfig(BrokerBaseSettings):
+    # Same env vars as pact broker CLI client
+    # https://github.com/pact-foundation/pact_broker-client#usage---cli
+    base_url: str
+    auth: Optional[BrokerBasicAuthConfig]
+
     @property
     def auth_tuple(self) -> Optional[Tuple[str, str]]:
         """
@@ -46,8 +54,8 @@ class BrokerConfig(BaseSettings):
         If username or password are present, will be Tuple[str,str],
         else None.
         """
-        if self.username or self.password:
-            return (self.username, self.password)
+        if self.auth:
+            return (self.auth.username, self.auth.password)
         return None
 
 

--- a/pact_testgen/broker.py
+++ b/pact_testgen/broker.py
@@ -9,7 +9,7 @@ from .models import Pact
 
 
 # For broker settings, we want to allow passing None for username
-# and password, and revert to loading from the environment. Howerver,
+# and password, and revert to loading from the environment. However,
 # we also want to prioritize username and password if they are passed
 # as init kwargs, but are not None. This pattern simplifies CLI option
 # handling, at the expense of additional complexity here.
@@ -17,7 +17,7 @@ from .models import Pact
 
 class InitSettingsSourceIgnoreNone(InitSettingsSource):
     """
-    An InitSettingsSource that does not propagate arguments
+    An InitSettingsSource that ignores arguments
     with a value of None.
     """
 

--- a/pact_testgen/broker.py
+++ b/pact_testgen/broker.py
@@ -76,6 +76,12 @@ def _build_contract_url(
     return urllib.parse.urljoin(base_url, path)
 
 
+def _make_broker_request(url: str, auth: Optional[Tuple[str, str]] = None) -> Dict:
+    resp = requests.get(url, auth=auth)
+    resp.raise_for_status()
+    return resp.json()
+
+
 def get_pact_from_broker(
     broker_config: BrokerConfig,
     provider_name: str,
@@ -88,6 +94,5 @@ def get_pact_from_broker(
     url = _build_contract_url(
         broker_config.base_url, provider_name, consumer_name, version=version
     )
-    resp = requests.get(url, auth=broker_config.auth_tuple)
-    resp.raise_for_status()
-    return Pact(**resp.json())
+    data = _make_broker_request(url, auth=broker_config.auth_tuple)
+    return Pact(**data)

--- a/pact_testgen/broker.py
+++ b/pact_testgen/broker.py
@@ -1,0 +1,60 @@
+import urllib
+from typing import Optional, Tuple
+
+import requests
+from pydantic import BaseSettings, Field
+from .models import Pact
+
+
+class BrokerConfig(BaseSettings):
+    # Same env vars as pact broker CLI client
+    # https://github.com/pact-foundation/pact_broker-client#usage---cli
+    base_url: str
+    username: str = Field(default="")
+    password: str = Field(default="")
+
+    class Config:
+        env_prefix = "pact_broker_"
+
+    @property
+    def auth_tuple(self) -> Optional[Tuple[str, str]]:
+        """
+        Returns auth value suitable for passing to requests.
+
+        If username or password are present, will be Tuple[str,str],
+        else None.
+        """
+        if self.username or self.password:
+            return (self.username, self.password)
+        return None
+
+
+def _build_contract_url(
+    base_url: str, provider_name: str, consumer_name: str, version=None
+) -> str:
+    if version is None or version == "latest":
+        version = "latest"
+    else:
+        version = f"version/{version}"
+
+    path = urllib.parse.quote(
+        f"/pacts/provider/{provider_name}/consumer/{consumer_name}/{version}"
+    )
+    return urllib.parse.urljoin(base_url, path)
+
+
+def get_pact_from_broker(
+    broker_config: BrokerConfig,
+    provider_name: str,
+    consumer_name: str,
+    version=None,
+) -> Pact:
+    """
+    Make an HTTP request to the Pact Broker to retrieve the desired contract.
+    """
+    url = _build_contract_url(
+        broker_config.base_url, provider_name, consumer_name, version=version
+    )
+    resp = requests.get(url, auth=broker_config.auth_tuple)
+    resp.raise_for_status()
+    return Pact(**resp.json())

--- a/pact_testgen/cli.py
+++ b/pact_testgen/cli.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 from pathlib import Path
 from pact_testgen import __version__
+from pact_testgen.broker import BrokerConfig
 from pact_testgen.pact_testgen import run
 from pact_testgen.files import merge_is_available
 
@@ -17,10 +18,10 @@ def directory(path: str) -> Path:
 def main():
     """Console script for pact_testgen."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("pact_file", help="Path to a Pact file.")
     parser.add_argument(
         "output_dir", help="Output for generated Python files.", type=directory
     )
+    parser.add_argument("-f", "--pact-file", help="Path to a Pact file.")
     parser.add_argument(
         "--base-class",
         default="django.test.TestCase",
@@ -46,20 +47,75 @@ def main():
         help="Attempt to merge new provider state functions into existing "
         "provider state file. Only available on Python 3.9+.",
     )
-    # Reserve -b for Pact Broker support
+    # Options related to pact broker are the same as those for the pact broker CLI
+    # client, as much as possible
+    # https://github.com/pact-foundation/pact_broker-client#usage---cli
+
+    broker_group = parser.add_argument_group("pact broker arguments")
+
+    broker_group.add_argument(
+        "-b",
+        "--broker-base-url",
+        help="Pact broker base url. Optionally configure by setting the "
+        "PACT_BROKER_BASE_URL environment variable.",
+    )
+    broker_group.add_argument("-u", "--broker-username", help="Pact broker username.")
+    broker_group.add_argument("-p", "--broker-password", help="Pact broker password.")
+    broker_group.add_argument(
+        "-c",
+        "--consumer-name",
+        help="Consumer name used to retrieve Pact contract from the pact broker.",
+    )
+    broker_group.add_argument(
+        "-s",
+        "--provider-name",
+        help="Provider name used to retrieve Pact contract from the pact broker.",
+    )
+    broker_group.add_argument(
+        "-v",
+        "--consumer-version",
+        # Note we don't actually set default="latest" here, that happens
+        # later when constructing the URL. Here, we rely on consumer_version=None
+        # if it isn't specified.
+        help="Consumer version number. Used to retrieve the Pact contract from the "
+        "Pact broker. Optional, defaults to 'latest'.",
+    )
     args = parser.parse_args()
 
-    if args.merge_provider_state_file and not merge_is_available():
-        print(
-            "Merge provider state file is only available in Python 3.9+.",
-            file=sys.stderr,
+    # Either both, or neither, i.e. logical XNOR
+    if bool(args.consumer_name) ^ bool(args.provider_name):
+        parser.error(
+            "Must specify both --provider-name and --consumer-name, or neither."
         )
-        return 1
+
+    if args.broker_base_url and not args.consumer_name:
+        parser.error("Must specify consumer and provider names with pact broker URL.")
+
+    if args.pact_file and args.consumer_name:
+        parser.error("Specify either pact file or pact broker options, not both.")
+
+    if not (args.pact_file or args.consumer_name):
+        parser.error("Must provide a pact file with -f, or pact broker options.")
+
+    if args.consumer_version and not args.consumer_name:
+        parser.error("Must specify consumer name with consumer version.")
+
+    if args.merge_provider_state_file and not merge_is_available():
+        parser.error("Merge provider state file is only available in Python 3.9+.")
+
+    if args.consumer_name:
+        broker_config = BrokerConfig(base_url=args.broker_base_url)
+    else:
+        broker_config = None
 
     try:
         run(
             base_class=args.base_class,
             pact_file=args.pact_file,
+            broker_config=broker_config,
+            provider_name=args.provider_name,
+            consumer_name=args.consumer_name,
+            consumer_version=args.consumer_version,
             output_dir=args.output_dir,
             line_length=args.line_length,
             merge_ps_file=args.merge_provider_state_file,

--- a/pact_testgen/cli.py
+++ b/pact_testgen/cli.py
@@ -104,7 +104,11 @@ def main():
         parser.error("Merge provider state file is only available in Python 3.9+.")
 
     if args.consumer_name:
-        broker_config = BrokerConfig(base_url=args.broker_base_url)
+        broker_config = BrokerConfig(
+            base_url=args.broker_base_url,
+            username=args.broker_username,
+            password=args.broker.password,
+        )
     else:
         broker_config = None
 

--- a/pact_testgen/cli.py
+++ b/pact_testgen/cli.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 from pathlib import Path
 from pact_testgen import __version__
-from pact_testgen.broker import BrokerConfig
+from pact_testgen.broker import BrokerBasicAuthConfig, BrokerConfig
 from pact_testgen.pact_testgen import run
 from pact_testgen.files import merge_is_available
 
@@ -80,6 +80,7 @@ def main():
         help="Consumer version number. Used to retrieve the Pact contract from the "
         "Pact broker. Optional, defaults to 'latest'.",
     )
+
     args = parser.parse_args()
 
     # Either both, or neither, i.e. logical XNOR
@@ -106,8 +107,10 @@ def main():
     if args.consumer_name:
         broker_config = BrokerConfig(
             base_url=args.broker_base_url,
-            username=args.broker_username,
-            password=args.broker.password,
+            auth=BrokerBasicAuthConfig(
+                username=args.broker_username,
+                password=args.broker.password,
+            ),
         )
     else:
         broker_config = None

--- a/pact_testgen/utils.py
+++ b/pact_testgen/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any, Dict, List
 from urllib.parse import urlencode
 from slugify import slugify

--- a/pact_testgen/utils.py
+++ b/pact_testgen/utils.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Any, Dict, List
 from urllib.parse import urlencode
 from slugify import slugify

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ coverage==4.5.4
 flake8==3.7.8
 pip==21.1
 pytest==6.2.4
+requests-mock==1.9.3
 Sphinx==1.8.5
 tox==3.14.0
 twine==1.14.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["jinja2", "pydantic", "pactman", "python-slugify", "black"]
+requirements = ["jinja2", "pydantic", "pactman", "python-slugify", "black", "requests"]
 
 # Install typing_extensions on Python 3.7
 if sys.version_info < (3, 8):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,78 @@
+import pytest
+import requests_mock
+from requests.exceptions import HTTPError
+
+from pact_testgen.broker import (
+    BrokerConfig,
+    _build_contract_url,
+    _make_broker_request,
+    get_pact_from_broker,
+)
+from pact_testgen.models import Metadata, Pact, PactSpecification, Pacticipant
+
+from .utils import patch_env
+
+BROKER_BASE_URL = "http://example.com"
+PROVIDER = "TestProvider"
+CONSUMER = "TestConsumer"
+DEFAULT_URL = f"{BROKER_BASE_URL}/pacts/provider/{PROVIDER}/consumer/{CONSUMER}/latest"
+
+
+@pytest.fixture
+def brokerconfig():
+    with patch_env():
+        yield BrokerConfig(base_url=BROKER_BASE_URL)
+
+
+def test_build_broker_url_default_version():
+    url = _build_contract_url(
+        BROKER_BASE_URL, provider_name=PROVIDER, consumer_name=CONSUMER
+    )
+    assert url == DEFAULT_URL
+
+
+def test_build_broker_url_formatting_escapes():
+    url = _build_contract_url(
+        BROKER_BASE_URL,
+        provider_name="Test Provider",
+        consumer_name="Test Consumer",
+    )
+    assert url == (
+        f"{BROKER_BASE_URL}/pacts/provider/Test%20Provider/consumer/Test%20Consumer/latest"
+    )
+
+
+def test_build_broker_url_with_consumer_version():
+    VERSION = "123"
+    url = _build_contract_url(
+        BROKER_BASE_URL, provider_name=PROVIDER, consumer_name=CONSUMER, version=VERSION
+    )
+    assert url == (
+        f"{BROKER_BASE_URL}/pacts/provider/{PROVIDER}/consumer/{CONSUMER}/version/{VERSION}"
+    )
+
+
+def test_broker_request_throws(brokerconfig):
+    with requests_mock.Mocker() as m:
+        m.get(DEFAULT_URL, status_code=404, reason="Not Found")
+
+        with pytest.raises(HTTPError):
+            _make_broker_request(DEFAULT_URL)
+
+
+def test_receive_expected_response(brokerconfig):
+    pact = Pact(
+        consumer=Pacticipant(name=CONSUMER),
+        provider=Pacticipant(name=PROVIDER),
+        metadata=Metadata(PactSpecification=PactSpecification(version="3.0.0")),
+        interactions=[],
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get(DEFAULT_URL, text=pact.json())
+
+        retrieved_pact = get_pact_from_broker(
+            broker_config=brokerconfig, provider_name=PROVIDER, consumer_name=CONSUMER
+        )
+
+        assert retrieved_pact == pact

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -38,7 +38,8 @@ def test_build_broker_url_formatting_escapes():
         consumer_name="Test Consumer",
     )
     assert url == (
-        f"{BROKER_BASE_URL}/pacts/provider/Test%20Provider/consumer/Test%20Consumer/latest"
+        f"{BROKER_BASE_URL}/pacts/provider/Test%20Provider"
+        "/consumer/Test%20Consumer/latest"
     )
 
 
@@ -48,7 +49,8 @@ def test_build_broker_url_with_consumer_version():
         BROKER_BASE_URL, provider_name=PROVIDER, consumer_name=CONSUMER, version=VERSION
     )
     assert url == (
-        f"{BROKER_BASE_URL}/pacts/provider/{PROVIDER}/consumer/{CONSUMER}/version/{VERSION}"
+        f"{BROKER_BASE_URL}/pacts/provider/{PROVIDER}"
+        f"/consumer/{CONSUMER}/version/{VERSION}"
     )
 
 

--- a/tests/test_broker_config.py
+++ b/tests/test_broker_config.py
@@ -1,15 +1,6 @@
-from unittest.mock import patch
-import pytest
 from pact_testgen.broker import BrokerConfig
 
-
-class patch_env(patch.dict):
-    """
-    Patch environment variables. Clears by default. Use just like patch.dict.
-    """
-
-    def __init__(self, values=(), clear=True, **kwargs):
-        super().__init__("os.environ", values=values, clear=clear, **kwargs)
+from .utils import patch_env
 
 
 DEFAULTS = {

--- a/tests/test_broker_config.py
+++ b/tests/test_broker_config.py
@@ -1,45 +1,55 @@
-from pact_testgen.broker import BrokerConfig
+from pact_testgen.broker import BrokerBasicAuthConfig, BrokerConfig
 
 from .utils import patch_env
 
-
-DEFAULTS = {
-    "base_url": "http://example.com",
+AUTH = {
     "username": "broker-username",
     "password": "broker-password",
 }
+DEFAULTS = {
+    "base_url": "http://example.com",
+    "auth": AUTH,
+}
 
 # i.e. ENV_DEFAULTS = {"PACT_BROKER_BASE_URL": ...}
-ENV_DEFAULTS = {f"pact_broker_{k}".upper(): v for k, v in DEFAULTS.items()}
+ENV_DEFAULTS = {
+    "PACT_BROKER_BASE_URL": DEFAULTS["base_url"],
+    "PACT_BROKER_USERNAME": AUTH["username"],
+    "PACT_BROKER_PASSWORD": AUTH["password"],
+}
 
 
 @patch_env(ENV_DEFAULTS)
 def test_set_from_env():
-    config = BrokerConfig()
+    config = BrokerConfig(auth=BrokerBasicAuthConfig())
     assert config.base_url == DEFAULTS["base_url"]
-    assert config.username == DEFAULTS["username"]
-    assert config.password == DEFAULTS["password"]
+    assert config.auth.username == AUTH["username"]
+    assert config.auth.password == AUTH["password"]
 
 
 @patch_env(ENV_DEFAULTS)
 def test_none_init_values_defaults_to_env():
-    config = BrokerConfig(base_url=None, username=None, password=None)
+    config = BrokerConfig(
+        base_url=None, auth=BrokerBasicAuthConfig(username=None, password=None)
+    )
     assert config.base_url == DEFAULTS["base_url"]
-    assert config.username == DEFAULTS["username"]
-    assert config.password == DEFAULTS["password"]
+    assert config.auth.username == AUTH["username"]
+    assert config.auth.password == AUTH["password"]
 
 
 @patch_env(ENV_DEFAULTS)
 def test_init_values_override_env():
     values = {
         "base_url": "http://example.com:8000",
-        "username": "new-username",
-        "password": "new-password",
+        "auth": {
+            "username": "new-username",
+            "password": "new-password",
+        },
     }
     config = BrokerConfig(**values)
     assert config.base_url == values["base_url"]
-    assert config.username == values["username"]
-    assert config.password == values["password"]
+    assert config.auth.username == values["auth"]["username"]
+    assert config.auth.password == values["auth"]["password"]
 
 
 @patch_env()
@@ -51,4 +61,4 @@ def test_auth_tuple_no_creds():
 @patch_env()
 def test_auth_tuple_with_creds():
     config = BrokerConfig(**DEFAULTS)
-    assert config.auth_tuple == (DEFAULTS["username"], DEFAULTS["password"])
+    assert config.auth_tuple == (AUTH["username"], AUTH["password"])

--- a/tests/test_broker_config.py
+++ b/tests/test_broker_config.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+import pytest
+from pact_testgen.broker import BrokerConfig
+
+
+class patch_env(patch.dict):
+    """
+    Patch environment variables. Clears by default. Use just like patch.dict.
+    """
+
+    def __init__(self, values=(), clear=True, **kwargs):
+        super().__init__("os.environ", values=values, clear=clear, **kwargs)
+
+
+DEFAULTS = {
+    "base_url": "http://example.com",
+    "username": "broker-username",
+    "password": "broker-password",
+}
+
+# i.e. ENV_DEFAULTS = {"PACT_BROKER_BASE_URL": ...}
+ENV_DEFAULTS = {f"pact_broker_{k}".upper(): v for k, v in DEFAULTS.items()}
+
+
+@patch_env(ENV_DEFAULTS)
+def test_set_from_env():
+    config = BrokerConfig()
+    assert config.base_url == DEFAULTS["base_url"]
+    assert config.username == DEFAULTS["username"]
+    assert config.password == DEFAULTS["password"]
+
+
+@patch_env(ENV_DEFAULTS)
+def test_none_init_values_defaults_to_env():
+    config = BrokerConfig(base_url=None, username=None, password=None)
+    assert config.base_url == DEFAULTS["base_url"]
+    assert config.username == DEFAULTS["username"]
+    assert config.password == DEFAULTS["password"]
+
+
+@patch_env(ENV_DEFAULTS)
+def test_init_values_override_env():
+    values = {
+        "base_url": "http://example.com:8000",
+        "username": "new-username",
+        "password": "new-password",
+    }
+    config = BrokerConfig(**values)
+    assert config.base_url == values["base_url"]
+    assert config.username == values["username"]
+    assert config.password == values["password"]
+
+
+@patch_env()
+def test_auth_tuple_no_creds():
+    config = BrokerConfig(base_url="http://example.com")
+    assert config.auth_tuple is None
+
+
+@patch_env()
+def test_auth_tuple_with_creds():
+    config = BrokerConfig(**DEFAULTS)
+    assert config.auth_tuple == (DEFAULTS["username"], DEFAULTS["password"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,13 @@
+"""
+Utilities for testing
+"""
+from unittest.mock import patch
+
+
+class patch_env(patch.dict):
+    """
+    Patch environment variables. Clears by default. Use just like patch.dict.
+    """
+
+    def __init__(self, values=(), clear=True, **kwargs):
+        super().__init__("os.environ", values=values, clear=clear, **kwargs)


### PR DESCRIPTION
Load the pact contract from a pact broker, instead of a local file.

Configuration parameter names are identical to those used by the pact broker CLI tool, where possible:

Pact broker connection settings are identical to pact broker CLI:
* `-b`, `--broker-base-url`, or `PACT_BROKER_BASE_URL` env var
* `-u`, `--broker-username`, or `PACT_BROKER_USERNAME` env var
* `-p`, `--broker-password`, or `PACT_BROKER_PASSWORD` env var

Additionally, the user must specify pact consumer + provider names. 

* `-c`, `--consumer-name` for the consumer name
* `-p`, `--provider-name` for the provider name
* `-v`, `--consumer-version` if specifying a consumer version (optional)

These option names differ from the pact broker CLI. All pact broker cli commands use `-a` for this (for application?), but the pact broker CLI never requests both a consumer + provider name at the same time; the distinction either doesn't matter or is clear from the context of a particular sub command.

## Implementation Notes

A new `broker` module is added. Notably, it uses a `BaseSettings` pydantic class to handle broker connection settings.

The actual functionality of retrieving the Pact contract from the broker is a simple matter of constructing a URL from the given arguments, making an HTTP request, and passing the retrieved JSON to the same `Pact` constructor used by our file loading code. Easy peasy.

In order to simplify CLI code as much as possible, we'd like to construct a `BrokerConfig` by passing in whatever values our argparse namespace (`args`) has for `base_url`, `username`, and `password`. These could be `None`, in which case we'd like to default to the appropriate environment variable.

The default behavior of `BaseSettings` classes is that they take the value from init kwargs, if provided, even if that value is None. The docs for [changing priority](https://pydantic-docs.helpmanual.io/usage/settings/#changing-priority) describe how to e.g. prioritize environment variables over init kwargs, but we'd like to prioritize init kwargs when they are provided, even if the corresponding env var is set.

The workaround is a bunch of boilerplate, where we replace the default `InitSettingSource` with a subclass that ignores arguments with a value of None, and a `Config.customise_sources` hook to perform the necessary substitution. I honestly thought this would be simpler to accomplish, and now that it's written I'm wondering if it's just better to construct a kwargs dict in `cli.main` that only includes non-None arguments.